### PR TITLE
KAS-5030 added route to strip signatures for 1 piece

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,26 @@
 import { app, errorHandler } from 'mu';
 import bodyParser from 'body-parser';
-import { LOG_INCOMING_DELTAS } from './cfg';
+import { LOG_INCOMING_DELTAS, PIECE_RESOURCE_BASE } from './cfg';
 import DeltaCache from './lib/delta-cache';
 import DeltaHandler from './lib/delta-handler';
+import { stripSignaturesFromPiece } from './config/piece';
 
 app.get('/', function(_req, res) {
   res.send('👋 pdf-signature-remover service here');
+});
+
+app.post('/pieces/:piece_id/strip', async function(req, res) {
+  try {
+    const pieceUri = PIECE_RESOURCE_BASE + req.params.piece_id;
+    await stripSignaturesFromPiece(pieceUri);
+    res.status(200).json({ message: 'Successfully stripped signatures from piece', pieceUri });
+  } catch (error) {
+    console.log(error.message);
+    res.status(500).json({ 
+      error: 'Failed to strip signatures from piece',
+      message: error.message 
+    });
+  }
 });
 
 const cache = new DeltaCache();

--- a/cfg.js
+++ b/cfg.js
@@ -2,8 +2,10 @@ import path from 'path';
 import fs from 'fs';
 
 const APPLICATION_GRAPH = process.env.MU_APPLICATION_GRAPH || 'http://mu.semte.ch/application';
+const KANSELARIJ_GRAPH = process.env.KANSELARIJ_GRAPH || 'http://mu.semte.ch/graphs/organizations/kanselarij';
 const MU_APPLICATION_FILE_STORAGE_PATH = process.env.MU_APPLICATION_FILE_STORAGE_PATH || '';
 const FILE_RESOURCE_BASE = process.env.FILE_RESOURCE_BASE || 'http://themis.vlaanderen.be/id/bestand/';
+const PIECE_RESOURCE_BASE = process.env.PIECE_RESOURCE_BASE || 'http://themis.vlaanderen.be/id/stuk/';
 
 const LOG_INCOMING_DELTAS = isTruthy(process.env.LOG_INCOMING_DELTAS);
 
@@ -18,7 +20,9 @@ function isTruthy(value) {
 
 export {
   APPLICATION_GRAPH,
+  KANSELARIJ_GRAPH,
   FILE_STORAGE_PATH,
   FILE_RESOURCE_BASE,
+  PIECE_RESOURCE_BASE,
   LOG_INCOMING_DELTAS,
 }

--- a/config/delta-handling.js
+++ b/config/delta-handling.js
@@ -1,12 +1,6 @@
-import { uuid } from 'mu';
-import { updateSudo, querySudo } from '@lblod/mu-auth-sudo';
-
-import { FILE_RESOURCE_BASE } from '../cfg';
-import removeSignatures from '../lib/remove-signatures';
-import { createMuFile, pathToShareUri, readMuFile, writeMuFile } from '../lib/file';
-import { getFileFromPiece, isMainPiece, linkSignatureStrippedPDFToPiece } from "./piece";
-
-const KANSELARIJ_GRAPH = 'http://mu.semte.ch/graphs/organizations/kanselarij';
+import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
+import { stripSignaturesFromPiece } from "./piece";
+import { KANSELARIJ_GRAPH } from '../cfg';
 
 function getInterestedQuads(deltas) {
   const inserts = deltas
@@ -46,66 +40,11 @@ export default async function handle(deltas) {
 
   for (const quad of interestedQuads) {
     const pieceUri = quad.subject.value;
-    if (!await isMainPiece(pieceUri, KANSELARIJ_GRAPH, querySudo)) {
-      console.log(`Quad with subject <${pieceUri}> is not a "main" piece and we will not treat it further`);
-      continue;
+    try {
+      await stripSignaturesFromPiece(pieceUri, KANSELARIJ_GRAPH, querySudo, updateSudo);
+    } catch (error) {
+      console.log(error.message);
     }
-
-    const file = await getFileFromPiece(pieceUri, KANSELARIJ_GRAPH, querySudo);
-    if (file === null || (file?.format.indexOf('application/pdf') === -1 && file?.extension?.toLowerCase() !== 'pdf')) {
-      console.log(`Quad with subject <${pieceUri}> does not have a file or the file isn't a PDF, not processing further`);
-      continue;
-    }
-
-
-    const pdfBytes = readMuFile(file);
-    const pdfBytesWithoutSignatures = await removeSignatures(pdfBytes);
-
-    if (pdfBytesWithoutSignatures === null) {
-      console.log(`Quad with subject <${pieceUri}> did not have signatures in its file, not processing further`)
-      continue;
-    }
-
-    console.log(`Generated PDF without signatures for signed file ${file.uri}`);
-
-    const { id: physicalFileUuid, path: pdfWithoutSignaturesPath} = writeMuFile(pdfBytesWithoutSignatures);
-    console.log(`Wrote PDF without signatures to ${pdfWithoutSignaturesPath}`);
-
-
-    const now = new Date();
-    const virtualFileUuid = uuid();
-    const virtualFile = {
-      id: virtualFileUuid,
-      uri: FILE_RESOURCE_BASE + virtualFileUuid,
-      name: `${file.pieceName}.pdf`,
-      extension: 'pdf',
-      size: pdfBytesWithoutSignatures.byteLength,
-      created: now,
-      format: 'application/pdf',
-    };
-
-    const physicalFile = {
-      id: physicalFileUuid,
-      uri: pathToShareUri(pdfWithoutSignaturesPath),
-      name: `${physicalFileUuid}.pdf`,
-      extension: 'pdf',
-      size: pdfBytesWithoutSignatures.byteLength,
-      created: now,
-      format: 'application/pdf',
-    };
-
-    console.log(`Creating virtual mu-file ${virtualFile.uri}`);
-    await createMuFile(virtualFile, physicalFile, KANSELARIJ_GRAPH, updateSudo);
-
-    console.log(`Linking virtual mu-file ${virtualFile.uri} to piece ${pieceUri}`);
-    await linkSignatureStrippedPDFToPiece(
-      pieceUri,
-      file.uri,
-      virtualFile.uri,
-      !!file.derivedFile,
-      KANSELARIJ_GRAPH,
-      updateSudo
-    );
   }
   console.log('Finished handling incoming deltas');
 }

--- a/lib/file.js
+++ b/lib/file.js
@@ -62,8 +62,8 @@ WHERE {
 
 /**
  * Stores a virtual and physical file in the triplestore
- * @param {VirtualFile} virtualFile 
- * @param {PhysicalFile} physicalFile 
+ * @param {VirtualFile} virtualFile
+ * @param {PhysicalFile} physicalFile
  * @param {string} [graph=APPLICATION_GRAPH] The graph to write to
  * @param {Function} [updateFunction=update] The function to use to send the
  *   update query, most likelky value will be updateSudo
@@ -100,9 +100,47 @@ INSERT DATA {
   await updateFunction(queryString);
 };
 
+async function deleteMuFile(virtualFileUri, physicalFileUri, graph=APPLICATION_GRAPH, updateFunction=update) {
+  try {
+    fs.unlinkSync(physicalFileUri.replace('share://', '/share/'));
+  } catch (e) {
+    console.log(e);
+  }
+
+  const updateString = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX dbpedia: <http://dbpedia.org/ontology/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+DELETE WHERE {
+  GRAPH ${sparqlEscapeUri(graph)} {
+    ${sparqlEscapeUri(virtualFileUri)} a nfo:FileDataObject ;
+      mu:uuid ?id ;
+      nfo:fileName ?fileName ;
+      dct:format ?format ;
+      nfo:fileSize ?fileSize ;
+      dbpedia:fileExtension ?fileExtension ;
+      dct:created ?created ;
+      dct:modified ?modified .
+
+    ${sparqlEscapeUri(physicalFileUri)} a nfo:FileDataObject ;
+      nie:dataSource ${sparqlEscapeUri(virtualFileUri)} ;
+      mu:uuid ?pid ;
+      nfo:fileName ?pfileName ;
+      dct:format ?pformat ;
+      nfo:fileSize ?pfileSize ;
+      dbpedia:fileExtension ?pfileExtension ;
+      dct:created ?pcreated ;
+      dct:modified ?pmodified .
+  }
+}`;
+  await updateFunction(updateString);
+};
+
 /**
  * Reads the contents of the on-disk file represented by the virtual file
- * @param {VirtualFile} virtualFile 
+ * @param {VirtualFile} virtualFile
  * @returns {Uint8Array}
  */
 function readMuFile(virtualFile) {
@@ -114,7 +152,7 @@ function readMuFile(virtualFile) {
 /**
  * Writes the passed in data to disk, respecting the configured
  * MU_APPLICATION_FILE_STORAGE_PATH.
- * @param {Uint8Array} data 
+ * @param {Uint8Array} data
  * @returns {FileIdAndPath}
  */
 function writeMuFile(data) {
@@ -125,7 +163,7 @@ function writeMuFile(data) {
 }
 
 /**
- * @param {string} path 
+ * @param {string} path
  * @returns {string} The uri
  */
 function pathToShareUri(path) {
@@ -133,7 +171,7 @@ function pathToShareUri(path) {
 }
 
 /**
- * @param {string} uri 
+ * @param {string} uri
  * @returns {string} The path
  */
 function shareUriToPath(uri) {
@@ -143,6 +181,7 @@ function shareUriToPath(uri) {
 export {
   getMuFile,
   createMuFile,
+  deleteMuFile,
   readMuFile,
   writeMuFile,
   pathToShareUri,


### PR DESCRIPTION
Adds a POST route to strip a single piece which can be called from an authorized session in the browser.
See https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/519 for backend PR with the dispatcher config.

Also did some general code cleanup and modularization since I needed it anyway.