### PR TITLE
fix: replace pdf-lib version

### DIFF
--- a/lib/remove-signatures.js
+++ b/lib/remove-signatures.js
@@ -1,4 +1,4 @@
-import { PDFDocument } from "pdf-lib";
+import { PDFDocument } from "@cantoo/pdf-lib";
 
 /**
  * @param {string | Uint8Array | ArrayBuffer} pdfBytes
@@ -13,13 +13,8 @@ export default async function removeSignatures(pdfBytes) {
 
   let removedSignatures = false;
 
-  for (const field of form.getFields()) { 
+  for (const field of form.getFields()) {
     if (field.constructor.name === 'PDFSignature') {
-      // See: https://github.com/Hopding/pdf-lib/issues/1168#issuecomment-1321581900
-      while (field.acroField.getWidgets().length) {
-          field.acroField.removeWidget(0);
-      }
-
       form.removeField(field);
       removedSignatures = true;
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.1",
-    "pdf-lib": "^1.17.1"
+    "@cantoo/pdf-lib": "^2.4.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Hopding's version is unmaintained. Cantoo's seems to be more up-to-date.