### PR TITLE
Feature/kas 5041 retry main piece

### DIFF
--- a/cfg.js
+++ b/cfg.js
@@ -6,6 +6,7 @@ const KANSELARIJ_GRAPH = process.env.KANSELARIJ_GRAPH || 'http://mu.semte.ch/gra
 const MU_APPLICATION_FILE_STORAGE_PATH = process.env.MU_APPLICATION_FILE_STORAGE_PATH || '';
 const FILE_RESOURCE_BASE = process.env.FILE_RESOURCE_BASE || 'http://themis.vlaanderen.be/id/bestand/';
 const PIECE_RESOURCE_BASE = process.env.PIECE_RESOURCE_BASE || 'http://themis.vlaanderen.be/id/stuk/';
+const RETRY_TIMEOUT_MS = parseInt(process.env.RETRY_TIMEOUT_MS || '5000');
 
 const LOG_INCOMING_DELTAS = isTruthy(process.env.LOG_INCOMING_DELTAS);
 
@@ -25,4 +26,5 @@ export {
   FILE_RESOURCE_BASE,
   PIECE_RESOURCE_BASE,
   LOG_INCOMING_DELTAS,
+  RETRY_TIMEOUT_MS,
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5041

Bug of not stripping when we should is still active.
Trying to alleviate it by waiting 5 seconds before trying again.

Alternatives:
We could read every pdf (regardless if it passes the mainpiece check) and check for signatures.
Maybe we could email ourselves in certain scenarios if we can determine them.
In this case, we could add queries to verify if this piece is connected to agendaitem or subcase or meeting. 

We also didn't cover all cases:
you can upload a pdf and replace the file, and we will not strip it.
We could start doing this manually now on replace of pdf files